### PR TITLE
Corrected the incorrect URL for `Contributing to Nightwatch`

### DIFF
--- a/src/includes/sections/about.ejs
+++ b/src/includes/sections/about.ejs
@@ -319,7 +319,7 @@
             </p>
             <p>New contributors: please also have a look at these resources:</p>
             <ul>
-              <li><a href="https://github.com/nightwatchjs/nightwatch/blob/main/.github/CONTRIBUTING.md"
+              <li><a href="https://github.com/nightwatchjs/nightwatch/blob/main/CONTRIBUTING.md"
                      target="_blank">Contributing to Nightwatch</a></li>
               <li><a href="https://github.com/nightwatchjs/nightwatch/blob/main/CODE_OF_CONDUCT.md" target="_blank">Code
                   of Conduct</a></li>


### PR DESCRIPTION
Corrected the incorrect URL for 'Contributing to Nightwatch' on the https://nightwatchjs.org/about/community/ page with the appropriate URL.

<br>

![image](https://github.com/nightwatchjs/nightwatch-www/assets/91485305/1a975d01-ed08-4a78-8d2b-a71069881d6a)
