### PR TITLE
Fix broken links

### DIFF
--- a/src/includes/sections/about.ejs
+++ b/src/includes/sections/about.ejs
@@ -506,7 +506,7 @@
               </div>
               <div class="col p-4 d-flex flex-column position-static">
                 <strong class="d-inline-block mb-2">Article</strong>
-                <h3><a href="https://blog.percy.io/visual-testing-in-nightwatch-js-with-percy-1b68c122cf94"
+                <h3><a href="https://www.browserstack.com/guide/visual-regression-testing-in-nightwatchjs"
                        target="_blank">Visual testing in Nightwatch.js with Percy</a></h3>
                 <div class="mb-1 text-muted">Published on Dec 13, 2018 by <a href="https://twitter.com/d_jones"
                                                                              target="_blank">David Jones</a></div>

--- a/src/pages/guide/comparison-with-leading-frameworks.ejs
+++ b/src/pages/guide/comparison-with-leading-frameworks.ejs
@@ -141,7 +141,7 @@ const data = {
         <td>
           <span class="comp-yes">✅</span> <br>
           <p>Mobile web is just as easy to setup and supports everything from Desktop web.
-            <br><a href="#">Get Started</a>
+            <br><a href="https://nightwatchjs.org/guide/mobile-app-testing/introduction.html">Get Started</a>
           </p>
         </td>
         <td>❌</td>
@@ -229,7 +229,7 @@ const data = {
       </tr>
       <tr>
         <td><b>VS Code extension</b></td>
-        <td><span class="comp-yes">✅</span> <a href="#">Try now</a></td>
+        <td><span class="comp-yes">✅</span> <a href="https://marketplace.visualstudio.com/items?itemName=browserstackcom.nightwatch#:~:text=The%20Nightwatch%20Extension%20for%20Visual,in%20a%20single%2C%20integrated%20environment.html">Try now</a></td>
         <td>❌</td>
         <td><span class="comp-yes">✅</span></td>
       </tr>


### PR DESCRIPTION
1. In [comparison with leading frameworks](https://nightwatchjs.org/guide/comparison-with-leading-frameworks.html) two links are broken.
2. In [Articles and Tutorials](https://nightwatchjs.org/about/community/) this link is broken [Visual testing in Nightwatch.js with Percy](https://blog.percy.io/visual-testing-in-nightwatch-js-with-percy-1b68c122cf94)
I have found a alternative for this in browser stack. Can you please say on how to proceed? As the total content in the component should be changed I guess.
<img width="1022" alt="Screenshot 2024-03-06 at 3 58 11 AM" src="https://github.com/nightwatchjs/nightwatch-www/assets/133094641/d6fa77f4-ab44-4f2e-9276-321b43557033">
