### PR TITLE
Add style for 'language-yml' class.

### DIFF
--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1610,6 +1610,7 @@ code {
 
 .secondary pre,
 .secondary pre.language-bash,
+.secondary pre.language-yml,
 .secondary pre.language-javascript,
 .secondary pre.language-typescript {
   color: #f2f2f2;


### PR DESCRIPTION
This will allow us to use `language-yml` class in `nightwatch-docs` for representing the yml sample code, just like we have `language-javascript` for representing JS code.

